### PR TITLE
Fix typo that broke the build (on 64 bits, at least)

### DIFF
--- a/makefile
+++ b/makefile
@@ -65,7 +65,7 @@ RSRCS = \
 #	- 	if your library does not follow the standard library naming scheme,
 #		you need to specify the path to the library and it's name.
 #		(e.g. for mylib.a, specify "mylib.a" or "path/mylib.a")
-LIBS = be tracker translation localestub $(STDCPPLIPS)
+LIBS = be tracker translation localestub $(STDCPPLIBS)
 
 #	Specify additional paths to directories following the standard libXXX.so
 #	or libXXX.a naming scheme. You can specify full paths or paths relative


### PR DESCRIPTION
See [this build log](https://build.haiku-os.org/buildmaster/master/x86_64/logviewer.html?buildruns/8119/builds/78746.log), for example.

```
SnowView.cpp:(.text+0x111): undefined reference to `__dynamic_cast'
```

(change untested, but should be straight-forward / obvious enough, right?)